### PR TITLE
remove default font-size for mobile hamburgs

### DIFF
--- a/src/components/Header/MobilePopup.tsx
+++ b/src/components/Header/MobilePopup.tsx
@@ -37,7 +37,6 @@ class MobilePopup extends React.Component<any, any> {
           width: 100%;
           justify-self: end;
           text-align: right;
-          font-size: 2rem;
           @media (min-width: 940px) {
             display: none;
           }


### PR DESCRIPTION
remove the default font-size for mobile links in the header as it can't be overwritten (and is not always the right size)